### PR TITLE
Added setter to CrossPermissions

### DIFF
--- a/src/Plugin.Permissions/CrossPermissions.cs
+++ b/src/Plugin.Permissions/CrossPermissions.cs
@@ -10,10 +10,10 @@ namespace Plugin.Permissions
     {
         static Lazy<IPermissions> Implementation = new Lazy<IPermissions>(CreatePermissions, System.Threading.LazyThreadSafetyMode.PublicationOnly);
 
-        /// <summary>
-        /// Current settings to use
-        /// </summary>
-        public static IPermissions Current
+		/// <summary>
+		/// Current settings to use
+		/// </summary>
+		public static IPermissions Current
         {
             get
             {
@@ -22,8 +22,13 @@ namespace Plugin.Permissions
                 {
                     throw NotImplementedInReferenceAssembly();
                 }
-                return ret;
+				return ret;
             }
+
+			set
+			{
+				Implementation = new Lazy<IPermissions>(() => value);
+			}
         }
 
         static IPermissions CreatePermissions()


### PR DESCRIPTION
Changes Proposed in this pull request:

Since my app behaviour is seriously changing when permissions are granted or denied I want to be able to inject a custom implementation of the ISettings so I can unit test the behaviour of my MvvmCross services for different permissions / permission statusses. 
Added a setter to the CrossPermissions. 

```
[Test()]
		public async Task TestCase()
		{
			var shouldShowRequest = true;
			var permissionStatus = PermissionStatus.Denied;
			var permission = Permission.Location;

			var permissions = new CustomPermissionsImplementation(shouldShowRequest, permission, permissionStatus);

			CrossPermissions.Current = permissions;

			var result = await CrossPermissions.Current.ShouldShowRequestPermissionRationaleAsync(permission);

			Assert.AreEqual(shouldShowRequest, result);

			var status = await CrossPermissions.Current.RequestPermissionsAsync(Permission.Location);

			var expectedStatus = new Dictionary<Permission, PermissionStatus> { { permission, permissionStatus } };

			Assert.AreEqual(expectedStatus, status);
		}
```