### PR TITLE
Check For Key Before Accessing

### DIFF
--- a/samples/PermissionsSample/PermissionsSample/Utils.cs
+++ b/samples/PermissionsSample/PermissionsSample/Utils.cs
@@ -44,10 +44,15 @@ namespace PermissionsSample
 			if (request || permissionStatus != PermissionStatus.Granted)
 			{
 				var newStatus = await CrossPermissions.Current.RequestPermissionsAsync(permission);
+				
+				if (!newStatus.ContainsKey(permission))
+				{
+					return permissionStatus;					
+				}
 
 				permissionStatus = newStatus[permission];
 
-				if (newStatus.ContainsKey(permission) && newStatus[permission] != PermissionStatus.Granted)
+				if (newStatus[permission] != PermissionStatus.Granted)
 				{
 					permissionStatus = newStatus[permission];
 					var title = $"{permission} Permission";


### PR DESCRIPTION
Changes Proposed in this pull request:
- Moved the `ContainsKey()` check in sample code so the check is made before the first attempt to access it is made